### PR TITLE
A couple of bug fixes.

### DIFF
--- a/src/main/java/com/teammetallurgy/atum/blocks/BlockFertileSoil.java
+++ b/src/main/java/com/teammetallurgy/atum/blocks/BlockFertileSoil.java
@@ -7,6 +7,7 @@ import net.minecraft.block.BlockFarmland;
 import net.minecraft.block.BlockFlower;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -69,6 +70,9 @@ public class BlockFertileSoil extends BlockFarmland {
     }
 
     @Override
+    public void onFallenUpon(World world, int x, int y, int z, Entity entity, float par5Random) {}
+
+    @Override
     public boolean canSustainPlant(IBlockAccess world, int x, int y, int z, ForgeDirection direction, IPlantable plant) {
         EnumPlantType plantType = plant.getPlantType(world, x, y + 1, z);
 
@@ -77,9 +81,9 @@ public class BlockFertileSoil extends BlockFarmland {
         }
 
         if (plantType == EnumPlantType.Beach) {
-                boolean hasWater = (world.getBlock(x - 1, y, z).getMaterial() == Material.water) || (world.getBlock(x + 1, y, z).getMaterial() == Material.water) || (world.getBlock(x, y, z - 1).getMaterial() == Material.water) || (world.getBlock(x, y, z + 1).getMaterial() == Material.water);
+            boolean hasWater = (world.getBlock(x - 1, y, z).getMaterial() == Material.water) || (world.getBlock(x + 1, y, z).getMaterial() == Material.water) || (world.getBlock(x, y, z - 1).getMaterial() == Material.water) || (world.getBlock(x, y, z + 1).getMaterial() == Material.water);
 
-                return hasWater;
+            return hasWater;
         }
 
         return false;

--- a/src/main/java/com/teammetallurgy/atum/entity/EntityGhost.java
+++ b/src/main/java/com/teammetallurgy/atum/entity/EntityGhost.java
@@ -20,6 +20,7 @@ public class EntityGhost extends EntityMob {
 
     public EntityGhost(World par1World) {
         super(par1World);
+        this.isImmuneToFire = true;
         this.experienceValue = 6;
         cycleTime = (int) ((Math.random() * 40) + 80);
         cycleHeight = (int) (Math.random() * cycleTime);

--- a/src/main/java/com/teammetallurgy/atum/handler/event/AtumEventListener.java
+++ b/src/main/java/com/teammetallurgy/atum/handler/event/AtumEventListener.java
@@ -4,9 +4,12 @@ import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.stats.AchievementList;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.BonemealEvent;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 
 import com.teammetallurgy.atum.blocks.AtumBlocks;
@@ -78,5 +81,12 @@ public class AtumEventListener {
 
         return false;
 
+    }
+
+    @SubscribeEvent
+    public void onPickup(EntityItemPickupEvent pickupEvent) {
+        if (pickupEvent.item.getEntityItem().isItemEqual(new ItemStack(AtumBlocks.BLOCK_LOG))) {
+            pickupEvent.entityPlayer.triggerAchievement(AchievementList.mineWood);
+        }
     }
 }


### PR DESCRIPTION
To Glassmaker, explaining why I also added the two last commits to the PR:
After talking with ShadowClaimer we figured out that ghost burning was not intended.
Furthermore the Fertile Soil does currently turn into vanilla dirt when jumped on, after talking with ShadowClaimer we agreed that it makes the most sense, that normal fertile soil does not turn into anything when jumped on.